### PR TITLE
feat(restapi): support print gvproxy network stack information

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -128,8 +128,7 @@ func makeVMCfg(command *cli.Command) *vmconfig.VMConfig {
 
 func makeCmdline(command *cli.Command) *vmconfig.Cmdline {
 	cmdline := vmconfig.Cmdline{
-		Workspace: "/",
-		// TODO: bootstrap-arm64 -> boostrap
+		Workspace:     "/",
 		TargetBin:     "/bootstrap",
 		TargetBinArgs: append([]string{command.Args().First()}, command.Args().Tail()...),
 		Env:           command.StringSlice("envs"),

--- a/pkg/server/ignserver.go
+++ b/pkg/server/ignserver.go
@@ -40,8 +40,28 @@ func (s *Server) handleShowMounts(w http.ResponseWriter, r *http.Request) {
 	WriteJSON(w, http.StatusOK, s.Vmc.Mounts)
 }
 
+type GVProxyInfo struct {
+	ControlEndpoints    string `json:"gvproxy_control_endpoint,omitempty"`
+	VFKitSocketEndpoint string `json:"gvproxy_network_endpoint,omitempty"`
+}
+
+func (s *Server) handleGVProxyInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		WriteJSON(w, http.StatusMethodNotAllowed, nil)
+		return
+	}
+
+	info := GVProxyInfo{
+		ControlEndpoints:    s.Vmc.GVproxyEndpoint,
+		VFKitSocketEndpoint: s.Vmc.NetworkStackBackend,
+	}
+
+	WriteJSON(w, http.StatusOK, info)
+}
+
 func (s *Server) registerRouter() {
 	s.Mux.HandleFunc("/host/mounts", s.handleShowMounts)
+	s.Mux.HandleFunc("/network/info", s.handleGVProxyInfo)
 }
 
 func (s *Server) Start() error {


### PR DESCRIPTION
```sh
$ curl http://127.0.0.1:15731/network/info | jq
{
  "gvproxy_control_endpoint": "unix:///var/folders/dt/wqkv0wf13nl6n8jbf98jggjh0000gn/T/06338551/gvproxy-control.sock",
  "gvproxy_network_endpoint": "unixgram:///var/folders/dt/wqkv0wf13nl6n8jbf98jggjh0000gn/T/06338551/gvproxy-network-backend.sock"
}
```