### PR TITLE
feat(restapi): support /guestexec & /hostexec sse api

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -68,7 +68,7 @@ func attachConsole(ctx context.Context, command *cli.Command) error {
 	}
 
 	// make stdout/stderr pipe, so we can get the output of the cmdline in realtime
-	if err := cfg.MakeStdPipe(); err != nil {
+	if err = cfg.MakeStdPipe(); err != nil {
 		return fmt.Errorf("failed to make std pipe: %w", err)
 	}
 

--- a/pkg/server/guestexec.go
+++ b/pkg/server/guestexec.go
@@ -1,1 +1,0 @@
-package server


### PR DESCRIPTION
using curl as sse client:

```shell
curl -N http://localhost:15731/hostexec -X POST --data '{"bin":"ping","args":["-c","10","127.0.0.1"]}' 
```
